### PR TITLE
Script plugin bug fixes 

### DIFF
--- a/lider-console-script/src/tr/org/liderahenk/script/dialogs/ScriptDefinitionDialog.java
+++ b/lider-console-script/src/tr/org/liderahenk/script/dialogs/ScriptDefinitionDialog.java
@@ -76,7 +76,7 @@ public class ScriptDefinitionDialog extends DefaultLiderDialog {
 		lblLabel.setText(Messages.getString("SCRIPT_LABEL"));
 
 		txtLabel = new Text(composite, SWT.BORDER);
-		txtLabel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		txtLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		if (selectedScript != null && selectedScript.getLabel() != null) {
 			txtLabel.setText(selectedScript.getLabel());
 		}
@@ -204,3 +204,4 @@ public class ScriptDefinitionDialog extends DefaultLiderDialog {
 	}
 
 }
+

--- a/lider-script-db/src/main/java/tr/org/liderahenk/script/entities/ScriptFile.java
+++ b/lider-script-db/src/main/java/tr/org/liderahenk/script/entities/ScriptFile.java
@@ -37,7 +37,7 @@ public class ScriptFile implements Serializable {
 	@Column(name = "SCRIPT_TYPE", length = 1, nullable = false)
 	private Integer scriptType;
 
-	@Column(name = "LABEL", nullable = false, length = 255)
+	@Column(name = "LABEL", nullable = false, unique = true, length = 255)
 	private String label;
 
 	@Lob
@@ -117,3 +117,4 @@ public class ScriptFile implements Serializable {
 	}
 
 }
+


### PR DESCRIPTION
*  	Prevent saving multiple scripts with the same name
*  	Make sure label is only one line instead of filling all the gap